### PR TITLE
Style classes/fixes

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -218,7 +218,7 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
         // Fallback
         if (colorPalette === null) {
             this._source._iconContainer.set_style(
-                'border-radius: 5px;' +
+                'border-radius: 11px;' +
                 'background-gradient-direction: vertical;' +
                 'background-gradient-start: #e0e0e0;' +
                 'background-gradient-end: darkgray;'
@@ -228,7 +228,7 @@ var RunningIndicatorBase = class DashToDock_RunningIndicatorBase extends Indicat
         }
 
         this._source._iconContainer.set_style(
-            'border-radius: 5px;' +
+            'border-radius: 11px;' +
             'background-gradient-direction: vertical;' +
             'background-gradient-start: ' + colorPalette.original + ';' +
             'background-gradient-end: ' +  colorPalette.darker + ';'

--- a/dash.js
+++ b/dash.js
@@ -65,7 +65,7 @@ class DashToDock_MyDashActor extends St.Widget {
         });
 
         super._init({
-            name: 'dash',
+            name: 'dock',
             layout_manager: layout,
             clip_to_allocation: true,
             ...(this._isHorizontal ? {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,53 +1,7 @@
 /* Shrink the dash by reducing padding */
 #dashtodockContainer.shrink #dash,
 #dashtodockContainer.dashtodock #dash {
-    border:1px;
     padding:0px;
-}
-
-#dashtodockContainer.shrink.left #dash,
-#dashtodockContainer.dashtodock.left #dash {
-    border-left: 0px;
-}
-
-
-#dashtodockContainer.shrink.right #dash,
-#dashtodockContainer.dashtodock.right #dash {
-    border-right: 0px;
-}
-
-
-#dashtodockContainer.shrink.top #dash,
-#dashtodockContainer.dashtodock.top #dash {
-    border-top: 0px;
-}
-
-#dashtodockContainer.shrink.bottom #dash,
-#dashtodockContainer.dashtodock.bottom #dash {
-    border-bottom: 0px;
-}
-
-#dashtodockContainer.straight-corner #dash,
-#dashtodockContainer.shrink.straight-corner #dash {
-    border-radius: 0px;
-}
-
-/* for the built-in theme only, we control border radius directly for each
-position. In the other cases the border are taken dynamically from the theme */
-#dashtodockContainer.dashtodock.top #dash {
-    border-radius: 0px 0px 9px 9px;
-}
-
-#dashtodockContainer.dashtodock.bottom #dash {
-    border-radius: 9px 9px 0px 0px;
-}
-
-#dashtodockContainer.dashtodock.left #dash {
-    border-radius: 0px 9px 9px 0px;
-}
-
-#dashtodockContainer.dashtodock.right #dash {
-    border-radius: 9px 0px 0px 9px;
 }
 
 /* Scrollview style */
@@ -65,33 +19,30 @@ position. In the other cases the border are taken dynamically from the theme */
 #dashtodockContainer.dashtodock .dash-item-container > StButton {
     transition-duration: 250;
     background-size: contain;
+    border-radius: 11px;
 }
 
 #dashtodockContainer.shrink .dash-item-container > StButton,
 #dashtodockContainer.dashtodock .dash-item-container > StButton {
-   padding: 1px 2px;
+   padding: 0;
+   border-radius: 11px;
 }
 
-/* Dash height extended to the whole available vertical space */
-#dashtodockContainer.extended.top #dash,
-#dashtodockContainer.extended.right #dash,
-#dashtodockContainer.extended.bottom #dash,
-#dashtodockContainer.extended.left #dash {
-    border-radius: 0;
+#dashtodockContainer.running-dots .dash-item ,
+#dashtodockContainer.dashtodock .dash-item-container ,
+#dashtodockContainer.shrink .dash-item-container ,
+#dashtodockContainer.dashtodock .dash-item-container {
+    border-radius: 11px;
 }
 
 #dashtodockContainer.extended.top #dash,
 #dashtodockContainer.extended.bottom #dash {
-    border-left: 0px;
-    border-right: 0px;
     padding-top: 0px;
     padding-bottom: 0px;
 }
 
 #dashtodockContainer.extended.right #dash,
 #dashtodockContainer.extended.left #dash {
-    border-top: 0px;
-    border-bottom: 0px;
     padding-top: 0px;
     padding-bottom: 0px;
 }
@@ -100,17 +51,25 @@ position. In the other cases the border are taken dynamically from the theme */
 
 #dashtodockContainer.running-dots .app-well-app.running > .overview-icon,
 #dashtodockContainer.dashtodock .app-well-app.running > .overview-icon {
-	background-image:none;
+    background-image:none;
+    border-radius: 11px;
 }
 
 
 #dashtodockContainer.running-dots .app-well-app.focused  .overview-icon,
 #dashtodockContainer.dashtodock .app-well-app.focused  .overview-icon {
     background-color: rgba(238, 238, 236, 0.2);
+    border-radius: 11px;
+}
+
+#dashtodockContainer.running-dots .app-well-app.focused  .overview-icon:hover,
+#dashtodockContainer.dashtodock .app-well-app.focused  .overview-icon:hover {
+    background-color: rgba(238, 238, 236, 0.2);
+    border-radius: 11px;
 }
 
 #dashtodockContainer.dashtodock #dash {
-    background: #2e3436;
+    background: #2e2e2e;
 }
 
 #dashtodockContainer.dashtodock .progress-bar {

--- a/theming.js
+++ b/theming.js
@@ -180,6 +180,36 @@ var ThemeManager = class DashToDock_ThemeManager {
     _updateCustomStyleClasses() {
         let settings = Docking.DockManager.settings;
 
+        this._actor.add_style_class_name('cosmic-dock');
+
+        // Extended to screen edge style class
+        if (settings.get_boolean('extend-height'))
+            this._actor.add_style_class_name('extended');
+        else
+            this._actor.remove_style_class_name('extended');
+        
+        // Dock position: 1=Right, 2=Bottom, 3=Left, 0=Top(unused)
+        switch (settings.get_enum('dock-position')) {
+            case 1:
+                this._actor.remove_style_class_name('bottom');
+                this._actor.remove_style_class_name('left');
+                this._actor.add_style_class_name('side');
+                this._actor.add_style_class_name('right');
+                break;
+            case 2:
+                this._actor.add_style_class_name('bottom');
+                this._actor.remove_style_class_name('left');
+                this._actor.remove_style_class_name('side');
+                this._actor.remove_style_class_name('right');
+                break;
+            case 3:
+                this._actor.remove_style_class_name('bottom');
+                this._actor.add_style_class_name('left');
+                this._actor.add_style_class_name('side');
+                this._actor.remove_style_class_name('right');
+                break;
+        }
+
         if (settings.get_boolean('apply-custom-theme'))
             this._actor.add_style_class_name('dashtodock');
         else

--- a/theming.js
+++ b/theming.js
@@ -253,77 +253,9 @@ var ThemeManager = class DashToDock_ThemeManager {
         if (!this._dash._container.get_stage())
             return;
 
-        let settings = Docking.DockManager.settings;
-
-        // Remove prior style edits
-        this._dash._container.set_style(null);
-        this._transparency.disable();
-
-        // If built-in theme is enabled do nothing else
-        if (settings.get_boolean('apply-custom-theme'))
-            return;
-
-        let newStyle = '';
-        let position = Utils.getPosition(settings);
-
-        // obtain theme border settings
-        let themeNode = this._dash._container.get_theme_node();
-        let borderColor = themeNode.get_border_color(St.Side.TOP);
-        let borderWidth = themeNode.get_border_width(St.Side.TOP);
-        let borderRadius = themeNode.get_border_radius(St.Corner.TOPRIGHT);
-
-        // We're copying border and corner styles to left border and top-left
-        // corner, also removing bottom border and bottom-right corner styles
-        let borderInner = '';
-        let borderRadiusValue = '';
-        let borderMissingStyle = '';
-
-        if (this._rtl && (position != St.Side.RIGHT))
-            borderMissingStyle = 'border-right: ' + borderWidth + 'px solid ' +
-                   borderColor.to_string() + ';';
-        else if (!this._rtl && (position != St.Side.LEFT))
-            borderMissingStyle = 'border-left: ' + borderWidth + 'px solid ' +
-                   borderColor.to_string() + ';';
-
-        switch (position) {
-        case St.Side.LEFT:
-            borderInner = 'border-left';
-            borderRadiusValue = '0 ' + borderRadius + 'px ' + borderRadius + 'px 0;';
-            break;
-        case St.Side.RIGHT:
-            borderInner = 'border-right';
-            borderRadiusValue = borderRadius + 'px 0 0 ' + borderRadius + 'px;';
-            break;
-        case St.Side.TOP:
-            borderInner = 'border-top';
-            borderRadiusValue = '0 0 ' + borderRadius + 'px ' + borderRadius + 'px;';
-            break;
-        case St.Side.BOTTOM:
-            borderInner = 'border-bottom';
-            borderRadiusValue = borderRadius + 'px ' + borderRadius + 'px 0 0;';
-            break;
-        }
-
-        newStyle = borderInner + ': none;' +
-            'border-radius: ' + borderRadiusValue +
-            borderMissingStyle;
-
-        // I do call set_style possibly twice so that only the background gets the transition.
-        // The transition-property css rules seems to be unsupported
-        this._dash._container.set_style(newStyle);
-
-        // Customize background
-        let fixedTransparency = settings.get_enum('transparency-mode') == TransparencyMode.FIXED;
-        let defaultTransparency = settings.get_enum('transparency-mode') == TransparencyMode.DEFAULT;
-        if (!defaultTransparency && !fixedTransparency) {
-            this._transparency.enable();
-        }
-        else if (!defaultTransparency || settings.get_boolean('custom-background-color')) {
-            newStyle = newStyle + 'background-color:'+ this._customizedBackground + '; ' +
-                       'border-color:'+ this._customizedBorder + '; ' +
-                       'transition-delay: 0s; transition-duration: 0.250s;';
-            this._dash._container.set_style(newStyle);
-        }
+        // Upstream dash-to-dock has several theming items hardcoded here. Since
+        // the COSMIC dock just uses the built-in theme full-time, this can 
+        // be removed.
     }
 
     _bindSettingsChanges() {


### PR DESCRIPTION
This applies style classes to the dock to help ensure that our styling is always applied and doesn't apply to the default GNOME Shell dash or to the Dash-to-dock/Ubuntu Dock extensions. We also need to apply some tweaks to the built-in style which was overriding some of our CSS styling; this makes it so that more of the styling is applied by CSS instead of by the extension logic.

Fixes #1 