### PR TITLE
fix: tweak spacing between running dot and app icon/dock edge

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -403,10 +403,10 @@ var RunningIndicatorDots = class DashToDock_RunningIndicatorDots extends Running
             }
         }
 
-        // Define the radius as an arbitrary size, but keep large enough to account
-        // for the drawing of the border.
-        this._radius = Math.max(this._width/22, this._borderWidth/2);
-        this._padding = 0; // distance from the margin
+        // Dots need to be scaled by the scale factor. 
+        let scaleFactor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        this._radius = 2*scaleFactor;
+        this._padding = 2; // distance from the margin
         this._spacing = this._radius + this._borderWidth; // separation between the dots
      }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -84,6 +84,7 @@ class MyAppIcon extends Dash.DashIcon {
         this.remoteModel = remoteModel;
         this.iconAnimator = iconAnimator;
         this._indicator = null;
+        this.icon.add_style_class_name('dock-icon');
 
         let appInfo = app.get_app_info();
         this._location = appInfo ? appInfo.get_string('XdtdUri') : null;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -24,8 +24,8 @@
 
 #dashtodockContainer.shrink .dash-item-container > StButton,
 #dashtodockContainer.dashtodock .dash-item-container > StButton {
-   padding: 0;
-   border-radius: 11px;
+    padding: 0;
+    border-radius: 11px;
 }
 
 #dashtodockContainer.running-dots .dash-item ,
@@ -162,4 +162,8 @@
     background-image: url('./media/highlight_stacked_bg_h.svg');
     background-position: 0px 0px;
     background-size: contain;
+}
+
+.dock-icon {
+    padding: 8px;
 }


### PR DESCRIPTION
Moves the dot slightly further away from the screen edge and the app icon. This does require growing the dock slightly to accommodate the extra room, but at this size it looks to be a good tradeoff. Also shrinks the dots from ~5px to 4px (while ensuring they will scale with the screen scale factor) to help reduce the amount of space needed.