### PR TITLE
docs(readme): update with references for COSMIC Dock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,46 @@
-# Dash to Dock
+# COSMIC Dock
 ![screenshot](https://github.com/micheleg/dash-to-dock/raw/master/media/screenshot.jpg)
 
-## A dock for the GNOME Shell
-This extension enhances the dash moving it out of the overview and transforming it in a dock for an easier launching of applications and a faster switching between windows and desktops without having to leave the desktop view.
+## A dock for the Pop_Shell
+This extension adds a configurable dock to the system and allows it to be placed in both the overview and the desktop. It enables fast application switching and launching directly from the desktop view without needing to open the Applications view. COSMIC Dock is based on [Ubuntu Dock](https://github.com/micheleg/dash-to-dock/tree/ubuntu-dock) and [Dash-to-Dock](https://github.com/micheleg/dash-to-dock).
 
-For additional installation instructions and more information visit [https://micheleg.github.io/dash-to-dock/](https://micheleg.github.io/dash-to-dock/).
+This extension is part of [COSMIC](https://github.com/pop-os/cosmic), the Computer Operating System Main Interface Components.
 
-## Installation from source
+## Installation
+Installation is recommended from the package manager within Pop_OS. It should be pre-installed as part of COSMIC on Pop_OS 21.04 and later, but in case it isn't it can be installed using the following commands:
 
+```
+sudo apt install gnome-shell-extension-ubuntu-dock
+```
+
+### From source code
 The extension can be installed directly from source, either for the convenience of using git or to test the latest development version. Clone the desired branch with git
 
-<pre>git clone https://github.com/micheleg/dash-to-dock.git -b ubuntu-dock</pre>
+<pre>git clone https://github.com/pop-os/gnome-shell-extension-ubuntu-dock</pre>
 or download the branch from github. A simple Makefile is included. Then run
-<pre>make
+
+```
+make
 make install
-</pre>
-to install the extension in your home directory. A Shell reload is required <code>Alt+F2 r Enter</code> and the extension has to be enabled  with *gnome-tweak-tool* or with *dconf*.
+```
+to install the extension in your home directory. (Note, use of `sudo` is not necessary and is discouraged.)
 
-## Bug Reporting
+A Shell reload is required `Alt+F2` `r` `Enter` and the extension has to be enabled  with *gnome-tweak-tool*, *GNOME Extensions* or with *dconf*.
 
-Bugs should be reported to the Github bug tracker [https://github.com/micheleg/dash-to-dock/issues](https://github.com/micheleg/dash-to-dock/issues).
+## Removal
+If the extension is installed from source, it may be necessary to remove the manually-installed copy. The extension can be removed using this command:
+
+```
+rm -r ~/.local/share/gnome-shell/extensions/ubuntu-dock@ubuntu.com
+```
+
+## Bugs
+ Please report bugs in the Github issue tracker: https://github.com/pop-os/gnome-shell-extension-ubuntu-dock/issues
 
 ## License
-Dash to Dock Gnome Shell extension is distributed under the terms of the GNU General Public License,
+COSMIC Dock is distributed under the terms of the GNU General Public License,
 version 2 or later. See the COPYING file for details.
+
+## Special Thanks
+
+Special thanks to the team maintaining [Ubuntu Dock](https://github.com/micheleg/dash-to-dock/tree/ubuntu-dock) and [Dash-to-Dock](https://github.com/micheleg/dash-to-dock).


### PR DESCRIPTION
Update the documentation to reflect this is a fork, not the upstream project. Includes references to installing the extension on Pop as well as via source code, and attributes thanks to the upstream projects.