### PR TITLE
Make `intellihide-mode` default to `ALL_WINDOWS`

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -121,7 +121,7 @@
       <description>Enable or disable intellihide mode</description>
     </key>
     <key name="intellihide-mode" enum="org.gnome.shell.extensions.dash-to-dock.intellihide-mode">
-      <default>'FOCUS_APPLICATION_WINDOWS'</default>
+      <default>'ALL_WINDOWS'</default>
       <summary>Define which windows are considered for intellihide.</summary>
       <description></description>
     </key>


### PR DESCRIPTION
Fixes https://github.com/pop-os/gnome-shell-extension-ubuntu-dock/issues/8.