### PR TITLE
Enable `show mounts` by default

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -226,7 +226,7 @@
       <description>Show or hide the trash can icon in the dash</description>
     </key>
     <key type="b" name="show-mounts">
-      <default>false</default>
+      <default>true</default>
       <summary>Show mounted volumes and devices</summary>
       <description>Show or hide mounted volume and device icons in the dash</description>
     </key>


### PR DESCRIPTION
Mentioned in https://github.com/pop-os/desktop-widget/issues/16