### PR TITLE
Change click-action to minimize-or-previews

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -278,7 +278,7 @@
       <summary>Activate only one window</summary>
     </key>
     <key name="click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
-      <default>'cycle-windows'</default>
+      <default>'minimize-or-previews'</default>
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when clicking on the icon of a running application</description>
     </key>


### PR DESCRIPTION
Maybe this is just my preference, but currently clicking icon of a single open window on the dock does nothing.

If 2 windows of an app are open it cycles through them.

This feels sort of clunky to me, especially when you have more than a few windows of an app open at the same time.

The 'minimize-or-previews' option works similar to most other docks out there where clicking an app with a single instance minimizes it to the dock.

When there are multiple windows of an app open, clicking the app icon will now show a small preview of all its windows so you can quickly click on the one you are looking for.