### PR TITLE
fix: Hide `DashSpacer` when `manualhide` is enabled

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -651,6 +651,11 @@ var DockedDash = GObject.registerClass({
         else
             this._intellihide.disable();
 
+        if (this._manualhideIsEnabled)
+            this._dashSpacer.setDashActor(null);
+        else
+            this._dashSpacer.setDashActor(this._box);
+
         this._updateDashVisibility();
     }
 


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic/issues/56.