### PR TITLE
fix(css): fix app highlights not extending to dock edge

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -90,17 +90,6 @@ $osd_fg_color: #eeeeec;
     }
 }
 
-@each $side in bottom, top, left, right {
-    #dashtodockContainer.extended.#{$side},
-    #dashtodockContainer.extended.shrink.#{$side} {
-        #dash .dash-background {
-            margin: 0;
-            padding: 0;
-            border-radius: 0;
-        }
-    }
-}
-
 #dashtodockContainer.dashtodock .app-well-app  .overview-icon {
     padding: 8px;
 }
@@ -115,6 +104,62 @@ $osd_fg_color: #eeeeec;
 #dashtodockContainer.dashtodock .app-well-app:hover  .overview-icon {
     background-color: rgba(238, 238, 236, 0.2);
     border-radius: $modal_radius + 1px;
+}
+
+@each $side in bottom, top, left, right {
+    #dashtodockContainer.extended.#{$side},
+    #dashtodockContainer.extended.shrink.#{$side} {
+        margin: 0;
+        padding: 0;
+        
+        #dash {
+            margin: 0;
+            padding: 0;
+
+            .dash-background {
+                margin: 0;
+                margin-#{$side}: 0;
+                margin-#{opposite($side)}: 0;
+                padding: 0;
+                border-radius: 0;
+            }
+
+            .dash-separator {
+                @if $side == top or $side == bottom {
+                    margin-bottom: 0;
+                } @else {
+                    height: 1px;
+                    margin: ($dash_spacing + ($dash_padding / 2)) 0;
+                    background-color: transparentize($osd_fg_color, 0.7);
+                }
+            }
+
+            #dashtodockContainer {
+                margin: 50%;
+                margin-#{$side}: 0;
+                margin-#{opposite($side)}: 0;
+                padding: 0;
+                spacing: 0;
+            }
+
+            .dash-item-container {
+                margin: 0;
+                margin-#{opposite($side)}: 0;
+
+                .app-well-app,
+                .show-apps {
+                    margin: 0;
+                    padding: 0;
+                    padding-#{$side}: 0px;
+                    padding-#{opposite($side)}: 0px;
+                }
+            }
+        }
+
+        .app-well-app  .overview-icon {
+            padding: 12px;
+        }
+    }
 }
 
 #dashtodockContainer .number-overlay {


### PR DESCRIPTION
In the current CSS rewrite, the dock icons don't extend to the edge of the dock when the dock is extended. This corrects this and allows dock icon highlights to extend to the edge of the dock.