### PR TITLE
Limit Indicators to 4

### DIFF
--- a/appIconIndicators.js
+++ b/appIconIndicators.js
@@ -394,7 +394,7 @@ var RunningIndicatorDots = class DashToDock_RunningIndicatorDots extends Running
 
     _drawIndicator(cr) {
         // Draw the required numbers of dots
-        let n = this._source.windowsCount;
+        let n = Math.min(4, this._source.windowsCount);
 
         cr.setLineWidth(this._borderWidth);
         Clutter.cairo_set_source_color(cr, this._borderColor);


### PR DESCRIPTION
Potentially closes #67 by matching 21.04 functionality.

In the future I would like to see the indicators switch from dots to some other indicator when greater than 4. I think that this should close #67, and there should be a new issue and some discussion for an indicator at 4+ windows? What do you all think?