### PR TITLE
Fix click action preferences

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -192,7 +192,7 @@ $osd_fg_color: #eeeeec;
     border-radius: 12px;
 }
 
-#dashtodockWindowPreviewMenu .window-close {
+#dashtodockWindowPreview .window-close {
     width: 18px;
     height: 18px;
     padding: 2px;

--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -177,3 +177,34 @@ $osd_fg_color: #eeeeec;
     text-align: center;
     margin: 2px;
 }
+
+/* Window Previews popup */
+
+#dashtodockWindowPreviewMenu {
+    -arrow-border-radius: 12px;
+}
+
+#dashtodockWindowList {
+    padding: 0 12px;
+}
+
+#dashtodockWindowList #dashtodockWindowPreview {
+    border-radius: 12px;
+}
+
+#dashtodockWindowPreviewMenu .window-close {
+    width: 18px;
+    height: 18px;
+    padding: 2px;
+}
+
+#dashtodockPreviewSeparator.popup-separator-menu-item-horizontal {
+    width: 1px;
+    height: auto;
+    border-right-width: 1px;
+    margin: 32px 0px;
+}
+
+.dashtodock-app-well-preview-menu-item {
+    padding: 1em 1em 0.5em 1em;
+}

--- a/appIcons.js
+++ b/appIcons.js
@@ -469,7 +469,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         // We customize the action only when the application is already running
         if (this.running) {
             const hasUrgentWindows = !!this._urgentWindows.size;
-            const singleOrUrgentWindows = windows.length === 1 || !hasUrgentWindows;
+            const singleOrUrgentWindows = windows.length === 1 || hasUrgentWindows;
             switch (buttonAction) {
             case clickAction.MINIMIZE:
                 // In overview just activate the app, unless the acion is explicitely

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -293,7 +293,7 @@
       <summary>Activate only one window</summary>
     </key>
     <key name="click-action" enum="org.gnome.shell.extensions.dash-to-dock.clickAction">
-      <default>'minimize-or-previews'</default>
+      <default>'cycle-windows'</default>
       <summary>Action when clicking on a running app</summary>
       <description>Set the action that is executed when clicking on the icon of a running application</description>
     </key>

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -36,6 +36,7 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         let monitorIndex = this._source.monitorIndex;
 
         this.actor.add_style_class_name('app-well-menu');
+        this.actor.add_style_class_name('app-preview-menu');
         this.actor.set_name('dashtodockWindowPreviewMenu');
         this.actor.set_style('max-width: '  + (Main.layoutManager.monitors[monitorIndex].width  - 22) + 'px; ' +
                              'max-height: ' + (Main.layoutManager.monitors[monitorIndex].height - 22) + 'px;');


### PR DESCRIPTION
This PR brings back the window preview functionality and related styling in 21.10. (The functionality itself was broken because of a single-character difference between this fork and upstream.)

In addition to reaching par with 21.04, the third commit applies the window close button size to a better selector so it matches between the left-click previews menu and the right-click "All Windows" previews menu.

21.04 (mismatching close buttons):
![Screenshot from 2021-11-12 11-55-56](https://user-images.githubusercontent.com/7199422/141520555-a4fb685c-7601-4f85-9fa7-4485f39b1770.png)
![Screenshot from 2021-11-12 11-56-01](https://user-images.githubusercontent.com/7199422/141520603-36e6e3d4-5060-4f45-8698-332d9eafbda3.png)

21.10 (matching close buttons):
![Screenshot from 2021-11-12 11-34-36](https://user-images.githubusercontent.com/7199422/141520556-ae3d9c55-5fb6-46f3-bf0d-90ec4997ddd1.png)
![Screenshot from 2021-11-12 11-34-40](https://user-images.githubusercontent.com/7199422/141520608-4e024219-2f92-414f-8887-e682ecf51553.png)

