### PR TITLE
[21.10] Don't animate in every time the screen unlocks

### DIFF
--- a/docking.js
+++ b/docking.js
@@ -280,7 +280,7 @@ var DockedDash = GObject.registerClass({
         this._slider = new DashSlideContainer({
             monitor_index: this._monitor.index,
             side: this._position,
-            slide_x: 0,
+            slide_x: Main.layoutManager._startingUp ? 0 : 1,
             ...(this._isHorizontal ? {
                 x_align: Clutter.ActorAlign.CENTER,
             } : {


### PR DESCRIPTION
This upstream commit (from https://github.com/micheleg/dash-to-dock/pull/1540) stops the dock from animating in when the screen unlocks.

This does not stop the windows behind the dock from still needing to resize/adjust (something they didn't do in 21.04), but it is an improvement over the current 21.10 behavior.

Before:

https://user-images.githubusercontent.com/7199422/144119420-bf515758-08de-4875-9fa8-0d97ae053a2a.mp4

After:

https://user-images.githubusercontent.com/7199422/144119423-7ea1208a-d171-417f-bca3-48a34c647ad0.mp4
