### PR TITLE
fix: Do not close overview on opening `pop-cosmic-applications.desktop`

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -611,7 +611,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         }
 
         // Hide overview except when action mode requires it
-        if(shouldHideOverview) {
+        if(shouldHideOverview && this.app.id !== 'pop-cosmic-applications.desktop') {
             Main.overview.hide();
         }
     }


### PR DESCRIPTION
Fixes click on "Show Applications" to close. Also requires Cosmic change.