### PR TITLE
theming: Use rgba color when using fixed opacity with custom color

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -162,20 +162,24 @@ var ThemeManager = class DashToDock_ThemeManager {
             // Note that if using 'dynamic' transparency modes,
             // the opacity will be set by the opaque/transparent styles anyway.
             let newAlpha = Math.round(backgroundColor.alpha/2.55)/100;
-            if (settings.get_enum('transparency-mode') == TransparencyMode.FIXED)
-                newAlpha = settings.get_double('background-opacity');
 
             backgroundColor = settings.get_string('background-color');
-            this._customizedBackground = backgroundColor;
-
-            this._customizedBorder = this._customizedBackground;
-
             // backgroundColor is a string like rgb(0,0,0)
             const [ret, color] = Clutter.Color.from_string(backgroundColor);
             if (!ret) {
                 logError(new Error(`${backgroundColor} is not a valid color string`));
                 return;
             }
+
+            if (settings.get_enum('transparency-mode') == TransparencyMode.FIXED) {
+                newAlpha = settings.get_double('background-opacity');
+                this._customizedBackground =
+                    `rgba(${color.red}, ${color.blue}, ${color.green}, ${newAlpha})`;
+            } else {
+                this._customizedBackground = backgroundColor;
+            }
+
+            this._customizedBorder = this._customizedBackground;
 
             color.alpha = newAlpha * 255;
             this._transparency.setColor(color);


### PR DESCRIPTION
Fixes an issue introduced with 3b5778d1f0dc813b3de038858033f8584d33320f, where the `background-opacity` property would be ignored when the `custom-background-color` property was set, causing the resulting background color to always be fully opaque.

The fix was originally submitted to the master branch of the dash-to-dock repository (https://github.com/micheleg/dash-to-dock/commit/c9a83048bb9c5e0e1cce5ac24e602df426f19da0), I simply cherry-picked the commit.

This kind of addresses https://github.com/pop-os/cosmic/issues/31#issuecomment-876736976, as changes to the `background-opacity` property made via dconf-editor now take effect even if a custom background color is set.
