### PR TITLE
locations: Do not manually dispose objects

### DIFF
--- a/fileManager1API.js
+++ b/fileManager1API.js
@@ -64,7 +64,7 @@ var FileManager1Client = class DashToDock_FileManager1Client {
     destroy() {
         this._cancellable.cancel();
         this._signalsHandler.destroy();
-        this._proxy.run_dispose();
+        this._proxy = null;
     }
 
     /**

--- a/locations.js
+++ b/locations.js
@@ -505,7 +505,7 @@ var Removables = class DashToDock_Removables {
 
     destroy() {
         this._signalsHandler.destroy();
-        this._monitor.run_dispose();
+        this._monitor = null;
     }
 
     _getWorkingIconName(icon) {


### PR DESCRIPTION
This applies upstream commit https://github.com/micheleg/dash-to-dock/pull/1576 to fix https://bugs.launchpad.net/ubuntu/+source/gnome-shell-extension-ubuntu-dock/+bug/1951786, which mainly clears up logs (may help with https://github.com/pop-os/cosmic-dock/issues/98).