### PR TITLE
theming: Fix green/blue background channels

### DIFF
--- a/theming.js
+++ b/theming.js
@@ -174,7 +174,7 @@ var ThemeManager = class DashToDock_ThemeManager {
             if (settings.get_enum('transparency-mode') == TransparencyMode.FIXED) {
                 newAlpha = settings.get_double('background-opacity');
                 this._customizedBackground =
-                    `rgba(${color.red}, ${color.blue}, ${color.green}, ${newAlpha})`;
+                    `rgba(${color.red}, ${color.green}, ${color.blue}, ${newAlpha})`;
             } else {
                 this._customizedBackground = backgroundColor;
             }


### PR DESCRIPTION
Due to an oversight on my part my last pull request #106 introduced an issue where the blue and green color channels of a custom background color are swapped. 

Although this does not really affect the default color (the difference between `#33302f` and `#332f30` is veeeeery subtle after all...), it is quite bothersome for more *aggressive* color choices.

This pull request therefore contains upstream commit https://github.com/micheleg/dash-to-dock/commit/f9fc5c4ae4143e1441c15dff848582820403bb94, which fixes this issue.