### PR TITLE
[jammy] fix: Do not close overview on opening `pop-cosmic-applications.desktop`

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -616,7 +616,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         }
 
         // Hide overview except when action mode requires it
-        if(shouldHideOverview) {
+        if(shouldHideOverview && this.app.id !== 'pop-cosmic-applications.desktop') {
             Main.overview.hide();
         }
     }


### PR DESCRIPTION
Cherry picked from https://github.com/pop-os/cosmic-dock/pull/91.

Fixes https://github.com/pop-os/cosmic/issues/329.