### PR TITLE
Fix for dock hiding when popup menu is open

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -616,7 +616,7 @@ var DockAbstractAppIcon = GObject.registerClass({
         }
 
         // Hide overview except when action mode requires it
-        if(shouldHideOverview && this.app.id !== 'pop-cosmic-applications.desktop') {
+        if(Main.overview.visible && shouldHideOverview && this.app.id !== 'pop-cosmic-applications.desktop') {
             Main.overview.hide();
         }
     }
@@ -637,6 +637,8 @@ var DockAbstractAppIcon = GObject.registerClass({
             this._previewMenu.connect('open-state-changed', (menu, isPoppedUp) => {
                 if (!isPoppedUp)
                     this._onMenuPoppedDown();
+                else
+                    this.emit('menu-state-changed', true);
             });
             let id = Main.overview.connect('hiding', () => {
                 this._previewMenu.close();

--- a/dash.js
+++ b/dash.js
@@ -84,6 +84,7 @@ var DockDash = GObject.registerClass({
     },
     Signals: {
         'menu-closed': {},
+        'menu-opened': {},
         'icon-size-changed': {},
     }
 }, class DockDash extends St.Widget {
@@ -579,7 +580,9 @@ var DockDash = GObject.registerClass({
     _itemMenuStateChanged(item, opened) {
         Dash.Dash.prototype._itemMenuStateChanged.call(this, item, opened);
 
-        if (!opened) {
+        if (opened) {
+            this.emit('menu-opened');
+        } else {
             // I want to listen from outside when a menu is closed. I used to
             // add a custom signal to the appIcon, since gnome 3.8 the signal
             // calling this callback was added upstream.

--- a/docking.js
+++ b/docking.js
@@ -291,10 +291,15 @@ var DockedDash = GObject.registerClass({
             'status-changed',
             this._updateDashVisibility.bind(this)
         ], [
+            // keep dock visible while popupmenu is open
+            this.dash,
+            'menu-opened',
+            this._onMenuOpened.bind(this)
+        ], [
             // sync hover after a popupmenu is closed
             this.dash,
             'menu-closed',
-            () => { this._box.sync_hover() }
+            this._onMenuClosed.bind(this)
         ], [
             this.dash,
             'notify::requires-visibility',
@@ -693,6 +698,18 @@ var DockedDash = GObject.registerClass({
 
     _onOverviewHidden() {
         this.remove_style_class_name('overview');
+    }
+
+    _onMenuOpened() {
+        this._ignoreHover = true;
+        this._intellihide.disable();
+        this._removeAnimations();
+        this._animateIn(DockManager.settings.animationTime, 0);
+    }
+
+    _onMenuClosed() {
+        this._intellihide.enable();
+        this._updateDashVisibility();
     }
 
     _hoverChanged() {


### PR DESCRIPTION
Fixes https://github.com/pop-os/beta/issues/361

When the dock is set to "Always Hide" or "Intelligently Hide" and there is an application window overlapping the dock area, the dock disappears when window previews or the right-click popup menu open. This PR fixes that.