### PR TITLE
All windows jammy

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -1152,6 +1152,9 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
           if (windows.length > 0){
               this._allWindowsMenuItem.show();
               this._allWindowsMenuItem.setSensitive(true);
+
+              if (Docking.DockManager.settings.defaultWindowsPreviewToOpen)
+                  this._allWindowsMenuItem.menu.open();
           }
       }
 

--- a/appIcons.js
+++ b/appIcons.js
@@ -968,10 +968,12 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
         if (Docking.DockManager.settings.showWindowsPreview) {
             // Display the app windows menu items and the separator between windows
             // of the current desktop and other windows.
+            const windows = this._source.getInterestingWindows();
 
             this._allWindowsMenuItem = new PopupMenu.PopupSubMenuMenuItem(__('All Windows'), false);
             this._allWindowsMenuItem.hide();
-            this.addMenuItem(this._allWindowsMenuItem);
+            if (windows.length > 0)
+                this.addMenuItem(this._allWindowsMenuItem);
         } else {
             const windows = this._source.getInterestingWindows();
 
@@ -1145,7 +1147,7 @@ const DockAppIconMenu = class DockAppIconMenu extends PopupMenu.PopupMenu {
 
           }
 
-          // The menu is created hidden and never hidded after being shown. Instead, a singlal
+          // The menu is created hidden and never hidded after being shown. Instead, a signal
           // connected to its items destroy will set is insensitive if no more windows preview are shown.
           if (windows.length > 0){
               this._allWindowsMenuItem.show();

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -238,6 +238,11 @@
       <summary>Show preview of the open windows</summary>
       <description>Replace open windows list with windows previews</description>
     </key>
+    <key type="b" name="default-windows-preview-to-open">
+      <default>false</default>
+      <summary>Open windows preview by default</summary>
+      <description>Window previews will show windows by default, rather than hide them behind a drop dowm menu.</description>
+    </key>
     <key type="b" name="show-favorites">
       <default>true</default>
       <summary>Show favorites apps</summary>


### PR DESCRIPTION
This PR makes 2 changes

1. Hides the `All Windows` drop down when an app has no open windows
2. Adds a gsetting value to automatically open the `All Windows`. requested by https://twitter.com/postnick/status/1522315015067480070
    Enable: `gsettings set org.gnome.shell.extensions.dash-to-dock default-windows-preview-to-open true`
    Disable: `gsettings set org.gnome.shell.extensions.dash-to-dock default-windows-preview-to-open false`