### PR TITLE
Align icons within extended dock

### DIFF
--- a/dash.js
+++ b/dash.js
@@ -104,6 +104,7 @@ var DockDash = GObject.registerClass({
         this._position = Utils.getPosition();
         this._isHorizontal = ((this._position == St.Side.TOP) ||
                                (this._position == St.Side.BOTTOM));
+        this._alignment = Utils.getAlignment();
 
         this._dragPlaceholder = null;
         this._dragPlaceholderPos = -1;
@@ -120,8 +121,8 @@ var DockDash = GObject.registerClass({
 
         this._dashContainer = new St.BoxLayout({
             name: "dashtodockDashContainer",
-            x_align: Clutter.ActorAlign.CENTER,
-            y_align: Clutter.ActorAlign.CENTER,
+            x_align: this._alignment,
+            y_align: this._alignment,
             vertical: !this._isHorizontal,
             y_expand: this._isHorizontal,
             x_expand: !this._isHorizontal,
@@ -138,9 +139,9 @@ var DockDash = GObject.registerClass({
 
         if (Docking.DockManager.settings.dockExtended) {
             if (!this._isHorizontal) {
-                this._scrollView.y_align = Clutter.ActorAlign.CENTER;
+                this._scrollView.y_align = this._alignment;
             } else {
-                this._scrollView.x_align = Clutter.ActorAlign.CENTER;
+                this._scrollView.x_align = this._alignment;
             }
         }
 
@@ -152,7 +153,7 @@ var DockDash = GObject.registerClass({
             clip_to_allocation: false,
             ...(!this._isHorizontal ? { layout_manager: new DockDashIconsVerticalLayout() } : {}),
             x_align: rtl ? Clutter.ActorAlign.END : Clutter.ActorAlign.START,
-            y_align: this._isHorizontal ? Clutter.ActorAlign.CENTER: Clutter.ActorAlign.START,
+            y_align: this._isHorizontal ? this._alignment : Clutter.ActorAlign.START,
             y_expand: !this._isHorizontal,
             x_expand: this._isHorizontal
         });
@@ -728,9 +729,9 @@ var DockDash = GObject.registerClass({
 
         if (Docking.DockManager.settings.dockExtended) {
             if (!this._isHorizontal) {
-                this._scrollView.y_align = Clutter.ActorAlign.CENTER;
+                this._scrollView.y_align = this._alignment;
             } else {
-                this._scrollView.x_align = Clutter.ActorAlign.CENTER;
+                this._scrollView.x_align = this._alignment;
             }
         }
 
@@ -908,9 +909,9 @@ var DockDash = GObject.registerClass({
                 this._separator = new St.Widget({
                     style_class: 'dash-separator',
                     x_align: this._isHorizontal ?
-                        Clutter.ActorAlign.FILL : Clutter.ActorAlign.CENTER,
+                        Clutter.ActorAlign.FILL : this._alignment,
                     y_align: this._isHorizontal ?
-                        Clutter.ActorAlign.CENTER : Clutter.ActorAlign.FILL,
+                        this._alignment : Clutter.ActorAlign.FILL,
                     width: this._isHorizontal ? -1 : this.iconSize,
                     height: this._isHorizontal ? this.iconSize : -1,
                     reactive: true,

--- a/docking.js
+++ b/docking.js
@@ -1805,7 +1805,6 @@ var DockManager = class DashToDock_DockManager {
     _bindSettingsChanges() {
         this.settings.settingsSchema.list_keys().forEach(key => {
             const camelKey = key.replace(/-([a-z\d])/g, k => k[1].toUpperCase());
-            console.log("key", key, camelKey);
             const updateSetting = () => {
                 const schemaKey = this.settings.settingsSchema.get_key(key);
                 if (schemaKey.get_range().deepUnpack()[0] === 'enum')

--- a/docking.js
+++ b/docking.js
@@ -1805,6 +1805,7 @@ var DockManager = class DashToDock_DockManager {
     _bindSettingsChanges() {
         this.settings.settingsSchema.list_keys().forEach(key => {
             const camelKey = key.replace(/-([a-z\d])/g, k => k[1].toUpperCase());
+            console.log("key", key, camelKey);
             const updateSetting = () => {
                 const schemaKey = this.settings.settingsSchema.get_key(key);
                 if (schemaKey.get_range().deepUnpack()[0] === 'enum')
@@ -1848,6 +1849,10 @@ var DockManager = class DashToDock_DockManager {
         ], [
             this._settings,
             'changed::dock-position',
+            this._toggle.bind(this)
+        ], [
+            this._settings,
+            'changed::dock-alignment',
             this._toggle.bind(this)
         ], [
             this._settings,

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -26,7 +26,7 @@
     <value value='3' nick='LEFT'/>
   </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.alignment'>
-    <value value='0' nick='CENTRE'/>
+    <value value='0' nick='CENTER'/>
     <value value='1' nick='START'/>
     <value value='2' nick='END'/>
   </enum>
@@ -59,9 +59,9 @@
       <description>Dock is shown on the Left, Right, Top or Bottom side of the screen.</description>
     </key>
     <key name="dock-alignment" enum="org.gnome.shell.extensions.dash-to-dock.alignment">
-      <default>'CENTRE'</default>
+      <default>'CENTER'</default>
       <summary>Dock icon alignment</summary>
-      <description>Icons are aligned to Start, Centre, or End when dock extended to the edges of the screen.</description>
+      <description>Icons are aligned to Start, Center, or End when dock extended to the edges of the screen.</description>
     </key>
     <key type="d" name="animation-time">
       <default>0.2</default>

--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.xml
@@ -25,6 +25,11 @@
     <value value='2' nick='BOTTOM'/>
     <value value='3' nick='LEFT'/>
   </enum>
+  <enum id='org.gnome.shell.extensions.dash-to-dock.alignment'>
+    <value value='0' nick='CENTRE'/>
+    <value value='1' nick='START'/>
+    <value value='2' nick='END'/>
+  </enum>
   <enum id='org.gnome.shell.extensions.dash-to-dock.intellihide-mode'>
     <value value='0' nick='ALL_WINDOWS'/>
     <value value='1' nick='FOCUS_APPLICATION_WINDOWS'/>
@@ -52,6 +57,11 @@
       <default>'BOTTOM'</default>
       <summary>Dock position</summary>
       <description>Dock is shown on the Left, Right, Top or Bottom side of the screen.</description>
+    </key>
+    <key name="dock-alignment" enum="org.gnome.shell.extensions.dash-to-dock.alignment">
+      <default>'CENTRE'</default>
+      <summary>Dock icon alignment</summary>
+      <description>Icons are aligned to Start, Centre, or End when dock extended to the edges of the screen.</description>
     </key>
     <key type="d" name="animation-time">
       <default>0.2</default>

--- a/utils.js
+++ b/utils.js
@@ -383,6 +383,14 @@ function getPosition() {
     return position;
 }
 
+function getAlignment() {
+    return [
+        Clutter.ActorAlign.CENTER,
+        Clutter.ActorAlign.START,
+        Clutter.ActorAlign.END
+    ][Docking.DockManager.settings.dockAlignment];
+}
+
 function getPreviewScale() {
     return Docking.DockManager.settings.previewSizeScale;
 }


### PR DESCRIPTION
Adds an option (not exposed in the GUI) to align the icons in the dock to the center, start or end when extended (default center to not change functionality)
#34