### PR TITLE
Align non extended dock

### DIFF
--- a/_stylesheet.scss
+++ b/_stylesheet.scss
@@ -45,7 +45,9 @@ $osd_fg_color: #eeeeec;
         padding: 0;
         
         #dash {
-            margin: 0;
+            margin: $dock_side_margin;
+            margin-#{$side}: 0;
+            margin-#{opposite($side)}: 0;
             padding: 0;
 
             .dash-background {

--- a/docking.js
+++ b/docking.js
@@ -258,9 +258,9 @@ var DockedDash = GObject.registerClass({
             side: this._position,
             slide_x: Main.layoutManager._startingUp ? 0 : 1,
             ...(this._isHorizontal ? {
-                x_align: Clutter.ActorAlign.CENTER,
+                x_align: Utils.getAlignment(),
             } : {
-                y_align: Clutter.ActorAlign.CENTER,
+                y_align: Utils.getAlignment(),
             })
         });
 

--- a/docking.js
+++ b/docking.js
@@ -196,6 +196,7 @@ var DockedDash = GObject.registerClass({
 }, class DashToDock extends St.Bin {
     _init(params) {
         this._position = Utils.getPosition();
+        this._alignment = Utils.getAlignment();
         const positionStyleClass = ['top', 'right', 'bottom', 'left'];
 
         // This is the centering actor
@@ -1106,6 +1107,14 @@ var DockedDash = GObject.registerClass({
             this.x = workArea.x;
             this.y = pos_y;
 
+            let offset = (1 - fraction) / 2 * workArea.width;
+            if (this._alignment == Clutter.ActorAlign.CENTER)
+                this.x += Math.round(offset);
+            else if (!this._rtl && this._alignment == Clutter.ActorAlign.END)
+                this.x += Math.round(2 * offset);
+            else if (this._rtl && this._alignment == Clutter.ActorAlign.START)
+                this.x += Math.round(2 * offset);
+
             if (extendHeight) {
                 this.dash._container.set_width(this.width);
                 this.add_style_class_name('extended');
@@ -1122,6 +1131,12 @@ var DockedDash = GObject.registerClass({
 
             this.x = pos_x;
             this.y = workArea.y;
+
+            let offset = (1 - fraction) / 2 * workArea.height;
+            if (this._alignment == Clutter.ActorAlign.CENTER)
+                this.y += Math.round(offset);
+            else if (this._alignment == Clutter.ActorAlign.END)
+                this.y += Math.round(2 * offset);
 
             this._signalsHandler.removeWithLabel('verticalOffsetChecker');
 

--- a/docking.js
+++ b/docking.js
@@ -1103,7 +1103,7 @@ var DockedDash = GObject.registerClass({
             if (this._position == St.Side.BOTTOM)
                 pos_y += this._monitor.height;
 
-            this.x = workArea.x + Math.round((1 - fraction) / 2 * workArea.width);
+            this.x = workArea.x;
             this.y = pos_y;
 
             if (extendHeight) {
@@ -1121,7 +1121,7 @@ var DockedDash = GObject.registerClass({
                 pos_x += this._monitor.width;
 
             this.x = pos_x;
-            this.y = workArea.y + Math.round((1 - fraction) / 2 * workArea.height);
+            this.y = workArea.y;
 
             this._signalsHandler.removeWithLabel('verticalOffsetChecker');
 


### PR DESCRIPTION
Following the feedback on https://github.com/pop-os/desktop-widget/pull/98, this lets the dock be aligned to the left/right/etc of the screen when not extended too.