### PR TITLE
Fixed Scaling issues for the dock when previewing on different scales

### DIFF
--- a/appIcons.js
+++ b/appIcons.js
@@ -404,9 +404,15 @@ var DockAbstractAppIcon = GObject.registerClass({
                     const { dockFixed: fixedDock } = Docking.DockManager.settings;
                     let additional_margin = this._isHorizontal && !fixedDock ? Main.overview.dash.height : 0;
                     let verticalMargins = this._menu.actor.margin_top + this._menu.actor.margin_bottom;
+
+                    let scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+                    // Apparently "scale" can be invalid if the monitor is freshly unplugged/plugged in
+                    // So we need to just assume scale is the default of 1 in this case...
+                    if (scale == null || isNaN(scale) || scale < 1) { scale = 1; }
+
                     // Also set a max width to the menu, so long labels (long windows title) get truncated
-                    this._menu.actor.style = ('max-height: ' + Math.round(workArea.height - additional_margin - verticalMargins) + 'px;' +
-                                              'max-width: 400px');
+                    this._menu.actor.style = ('max-height: ' + parseInt((workArea.height - additional_margin - verticalMargins)/scale, 10) + 'px;' +
+                        'max-width: 400px');
                 }
             });
             let id = Main.overview.connect('hiding', () => {

--- a/windowPreview.js
+++ b/windowPreview.js
@@ -37,9 +37,15 @@ var WindowPreviewMenu = class DashToDock_WindowPreviewMenu extends PopupMenu.Pop
         this._app = this._source.app;
         let monitorIndex = this._source.monitorIndex;
 
+        let scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        // Apparently the scale can be invalid when a monitor is freshly unplugged/plugged in
+        // So we will assume the scale is just 1.
+        if (scale == null || isNaN(scale) || scale < 1) { scale = 1; }
+
         this.actor.add_style_class_name('app-menu');
-        this.actor.set_style('max-width: '  + (Main.layoutManager.monitors[monitorIndex].width  - 22) + 'px; ' +
-                             'max-height: ' + (Main.layoutManager.monitors[monitorIndex].height - 22) + 'px;');
+        this.actor.set_name('dashtodockWindowPreviewMenu');
+        this.actor.set_style('max-width: '  + (parseInt((Main.layoutManager.monitors[monitorIndex].width - 22) / scale, 10)) + 'px; ' +
+            'max-height: ' + (parseInt((Main.layoutManager.monitors[monitorIndex].height - 22) / scale, 10)) + 'px;');
         this.actor.hide();
 
         // Chain our visibility and lifecycle to that of the source


### PR DESCRIPTION
This fixed #44, a rebase of my #48 on to Jammy (with some new fixes).    This also has code to fix the potential error that was reported in #148 where apparently the the `scale` must be invalid directly after a monitor is plugged in/unplugged.  

In addition the original math for the windowPreview was subtracting -22 pixels AFTER the scale calculation, this 22 pixels  (11 for each side) should have been subtracted out before the `scale` was applied so that this window (see below) is actually centered properly on scaled displays.


![image](https://user-images.githubusercontent.com/850871/193682737-2d68fabe-dea6-42bb-b99f-a608b6e98149.png)

